### PR TITLE
Fix collection modified bug

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,5 +39,6 @@
     <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite</ResonitePath>
     <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite</ResonitePath>
     <ResonitePath Condition="Exists('D:/Files/Games/Resonite/app/')">D:/Files/Games/Resonite/app</ResonitePath>
+	<ResonitePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite')">G:\SteamLibrary\steamapps\common\Resonite</ResonitePath>
   </PropertyGroup>
 </Project>

--- a/InspectorPowerTools/LagFreeInspectorGeneration.cs
+++ b/InspectorPowerTools/LagFreeInspectorGeneration.cs
@@ -6,6 +6,7 @@ using MonkeyLoader.Resonite;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -60,7 +61,7 @@ namespace InspectorPowerTools
             switch (container)
             {
                 case Slot slot:
-                    foreach (var component in slot.Components)
+                    foreach (var component in slot.Components.ToArray())
                     {
                         if (workerFilter(component) && component is not GizmoLink)
                         {
@@ -72,7 +73,7 @@ namespace InspectorPowerTools
                     break;
 
                 case User user:
-                    foreach (var userComponent in user.Components)
+                    foreach (var userComponent in user.Components.ToArray())
                     {
                         if (workerFilter(userComponent))
                         {
@@ -81,7 +82,7 @@ namespace InspectorPowerTools
                         }
                     }
 
-                    foreach (var stream in user.Streams)
+                    foreach (var stream in user.Streams.ToArray())
                     {
                         if (workerFilter(stream))
                         {


### PR DESCRIPTION
https://discord.com/channels/901126079857692714/1364725144676990998

```
Exception running asynchronous task:
System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at async bool InspectorPowerTools.LagFreeInspectorGeneration.Prefix(WorkerInspector __instance, Worker container, Predicate<ISyncMember> memberFilter, Predicate<Worker> workerFilter, bool includeContainer)+(?) => { }
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at async bool InspectorPowerTools.LagFreeInspectorGeneration.Prefix(WorkerInspector __instance, Worker container, Predicate<ISyncMember> memberFilter, Predicate<Worker> workerFilter, bool includeContainer)+(?) => { }<---


   at void Elements.Core.UniLog.Error(string message, bool stackTrace)
   at void FrooxEngine.CoroutineManager.CheckExceptions(Task task)
   at void System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke()
   at void System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at bool System.Threading.ThreadPoolWorkQueue.Dispatch()
   at bool System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```